### PR TITLE
Allow mpHost override via window.MPCustomWidgetsConfig (no fork required)

### DIFF
--- a/dist/js/forceLogin.js
+++ b/dist/js/forceLogin.js
@@ -3,8 +3,18 @@
 // Simply include this script on any page with a user secured widget and it will automatically redirect to the SSO page and force the user to login
 
 // -------------------------------------------------------
-// CHANGE this to your MP HOST!!!
-const mpHost = 'mpi.ministryplatform.com';
+// MP HOST
+// Reads from window.MPCustomWidgetsConfig.mpHost if provided, else falls back
+// to the demo default below. To override without forking this file, set:
+//
+//   <script>window.MPCustomWidgetsConfig = { mpHost: 'your-tenant.host.com' };</script>
+//
+// BEFORE loading this script. Useful for CDN-served deployments and for keeping
+// per-tenant config separate from the shared widget code.
+//
+// If you fork: just CHANGE the fallback string below to your MP HOST.
+// -------------------------------------------------------
+const mpHost = (window.MPCustomWidgetsConfig && window.MPCustomWidgetsConfig.mpHost) || 'mpi.ministryplatform.com';
 // -------------------------------------------------------
 
 

--- a/src/forceLogin.js
+++ b/src/forceLogin.js
@@ -3,8 +3,18 @@
 // Simply include this script on any page with a user secured widget and it will automatically redirect to the SSO page and force the user to login
 
 // -------------------------------------------------------
-// CHANGE this to your MP HOST!!!
-const mpHost = 'mpi.ministryplatform.com';
+// MP HOST
+// Reads from window.MPCustomWidgetsConfig.mpHost if provided, else falls back
+// to the demo default below. To override without forking this file, set:
+//
+//   <script>window.MPCustomWidgetsConfig = { mpHost: 'your-tenant.host.com' };</script>
+//
+// BEFORE loading this script. Useful for CDN-served deployments and for keeping
+// per-tenant config separate from the shared widget code.
+//
+// If you fork: just CHANGE the fallback string below to your MP HOST.
+// -------------------------------------------------------
+const mpHost = (window.MPCustomWidgetsConfig && window.MPCustomWidgetsConfig.mpHost) || 'mpi.ministryplatform.com';
 // -------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Read `mpHost` from `window.MPCustomWidgetsConfig.mpHost` if provided; fall back to the existing `'mpi.ministryplatform.com'` default if not.
- Backward compatible — no behavior change for existing deployments.
- Same change in both `src/forceLogin.js` and `dist/js/forceLogin.js`, kept in lockstep since `CopyWebpackPlugin` copies `forceLogin.js` verbatim per the existing `webpack.config.js`.

## Why

The current `forceLogin.js` hardcodes `mpHost = 'mpi.ministryplatform.com'` and the README warns *"CHANGE this to your MP HOST!!!"* — which forces every customer to either fork this repo or manually edit a CDN-served file. Both are painful:

- **Forks drift from upstream over time.** Customers who only forked because of one string have to merge every upstream improvement by hand.
- **CDN-served files can't be edited at consume time.** Pinning to a forked commit just shifts the maintenance burden.

This change lets customers configure per-page without modifying widget code:

```html
<script>window.MPCustomWidgetsConfig = { mpHost: 'mychurch.ministryplatform.com' };</script>
<script src="https://cdn.jsdelivr.net/gh/MinistryPlatform-Community/MPCustomWidgets@main/dist/js/forceLogin.js"></script>
```

Same `forceLogin.js` works against any tenant. The "fork it" path is still available for anyone who wants compile-time control — just change the fallback string.

## Backward compatibility

If `window.MPCustomWidgetsConfig` isn't set (the existing case for everyone today), the script behaves exactly as before. Default mpHost remains `'mpi.ministryplatform.com'`.

## Naming

Picked `MPCustomWidgetsConfig` to namespace explicitly to this package and match the existing flat-on-window convention (`window.ReInitWidget`, `window.MPModal`, `window.ReinitAllWidgets`). Open to renaming if there's a different convention you'd prefer — let me know.

## Test plan

- [ ] Existing deployment with no config set — script behavior unchanged (falls back to `'mpi.ministryplatform.com'`)
- [ ] New deployment with `window.MPCustomWidgetsConfig = { mpHost: 'tenant.host.com' }` set before script load — script uses tenant host in the SSO redirect URL
- [ ] Smoke-tested locally against an MP sandbox tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)